### PR TITLE
(Should have) Improved performance when fetching itemstacks using the items 'SignName'

### DIFF
--- a/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -28,6 +28,8 @@ public class MaterialUtil {
 
     public static final boolean LONG_NAME = true;
     public static final boolean SHORT_NAME = false;
+    
+    private static final Map<String, Material> materialCache = new HashMap<String, Material>();
 
     /**
      * Checks if the itemStack is empty or null
@@ -57,8 +59,14 @@ public class MaterialUtil {
      * @return Material found
      */
     public static Material getMaterial(String name) {
-        Material material = Material.matchMaterial(name);
+        Material material = materialCache.get(name);
 
+        if (material != null) {
+            return material;
+        }
+        
+        material = Material.matchMaterial(name);
+        
         if (material != null) {
             return material;
         }
@@ -186,8 +194,11 @@ public class MaterialUtil {
                 }
             }
         }
-
-
+        
+        String signName = getSignName(itemStack);
+        if (!materialCache.containsKey(signName)) {
+            materialCache.put(signName, material);
+        }
         return itemStack;
     }
 


### PR DESCRIPTION
When an item is fetched from a string it caches the material in a
hashmap using the items sign name as the key.
This should massively improve performance when fetching itemstacks using
the string from signs. (Which should be mostly when it is needed)
