### PR TITLE
Added support for bank accounts

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
+++ b/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
@@ -48,8 +48,14 @@ public class Properties {
     @ConfigurationComment("The economy account which Admin Shops should use and to which all taxes will go")
     public static String SERVER_ECONOMY_ACCOUNT = "";
 
+    @ConfigurationComment("Whether bank account members (if available) can create shops on its behalf")
+    public static boolean BANK_MEMBERS_ALLOWED = true;
+
     @ConfigurationComment("Percent of the price that should go to the server's account. (100 = 100 percent)")
     public static int TAX_AMOUNT = 0;
+
+    @ConfigurationComment("Percent of the price that should go to the server's account when buying from a Bank.")
+    public static int BANK_TAX_AMOUNT = 0;
 
     @ConfigurationComment("Percent of the price that should go to the server's account when buying from an Admin Shop.")
     public static int SERVER_TAX_AMOUNT = 0;

--- a/src/main/java/com/Acrobot/ChestShop/Economy/EconomyManager.java
+++ b/src/main/java/com/Acrobot/ChestShop/Economy/EconomyManager.java
@@ -35,6 +35,46 @@ public class EconomyManager {
         return 0;
     }
 
+    public boolean hasBankSupport() {
+        printError();
+        return false;
+    }
+
+    public boolean bankExists(String bank) {
+        printError();
+        return false;
+    }
+
+    public boolean bankAdd(String bank, double amount) {
+        printError();
+        return false;
+    }
+
+    public boolean bankSubtract(String bank, double amount) {
+        printError();
+        return false;
+    }
+
+    public boolean bankHasEnough(String bank, double amount) {
+        printError();
+        return false;
+    }
+
+    public double bankBalance(String bank) {
+        printError();
+        return 0;
+    }
+
+    public boolean isBankOwner(String player, String bank) {
+        printError();
+        return false;
+    }
+
+    public boolean isBankMember(String player, String bank) {
+        printError();
+        return false;
+    }
+
     public String format(double amount) {
         printError();
         return null;

--- a/src/main/java/com/Acrobot/ChestShop/Economy/Register.java
+++ b/src/main/java/com/Acrobot/ChestShop/Economy/Register.java
@@ -36,6 +36,38 @@ public class Register extends EconomyManager {
         return method.getAccount(player).balance();
     }
 
+    public boolean hasBankSupport() {
+        return false;
+    }
+
+    public boolean bankExists(String bank) {
+        return false;
+    }
+
+    public boolean bankAdd(String bank, double amount) {
+        return false;
+    }
+
+    public boolean bankSubtract(String bank, double amount) {
+        return false;
+    }
+
+    public boolean bankHasEnough(String bank, double amount) {
+        return false;
+    }
+
+    public double bankBalance(String bank) {
+        return 0;
+    }
+
+    public boolean isBankOwner(String player, String bank) {
+        return false;
+    }
+
+    public boolean isBankMember(String player, String bank) {
+        return false;
+    }
+
     public String format(double amount) {
         return method.format(amount);
     }

--- a/src/main/java/com/Acrobot/ChestShop/Economy/Vault.java
+++ b/src/main/java/com/Acrobot/ChestShop/Economy/Vault.java
@@ -3,6 +3,8 @@ package com.Acrobot.ChestShop.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
+import java.util.List;
+
 /**
  * @author Acrobot
  */
@@ -31,6 +33,43 @@ public class Vault extends EconomyManager {
 
     public double balance(String player) {
         return vaultPlugin.getBalance(player);
+    }
+
+    public boolean hasBankSupport() {
+        return vaultPlugin.hasBankSupport() && !getPluginName().startsWith("iConomy");
+    }
+
+    public boolean bankExists(String bank) {
+        bank = bank.toLowerCase();
+        List<String> banks = vaultPlugin.getBanks();
+        for (String entry : banks) {
+            if (bank.equals(entry.toLowerCase())) return true;
+        }
+        return false;
+    }
+
+    public boolean bankAdd(String bank, double amount) {
+        return vaultPlugin.bankDeposit(bank, amount).transactionSuccess();
+    }
+
+    public boolean bankSubtract(String bank, double amount) {
+        return vaultPlugin.bankWithdraw(bank, amount).transactionSuccess();
+    }
+
+    public boolean bankHasEnough(String bank, double amount) {
+        return vaultPlugin.bankHas(bank, amount).transactionSuccess();
+    }
+
+    public double bankBalance(String bank) {
+        return vaultPlugin.bankBalance(bank).amount;
+    }
+
+    public boolean isBankOwner(String player, String bank) {
+        return vaultPlugin.isBankOwner(bank, player).transactionSuccess();
+    }
+
+    public boolean isBankMember(String player, String bank) {
+        return vaultPlugin.isBankMember(bank, player).transactionSuccess();
     }
 
     public String format(double amount) {

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/PreShopCreation/NameChecker.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/PreShopCreation/NameChecker.java
@@ -1,5 +1,7 @@
 package com.Acrobot.ChestShop.Listeners.PreShopCreation;
 
+import com.Acrobot.ChestShop.Configuration.Properties;
+import com.Acrobot.ChestShop.Economy.Economy;
 import com.Acrobot.ChestShop.Events.PreShopCreationEvent;
 import com.Acrobot.ChestShop.Permission;
 import com.Acrobot.ChestShop.Utils.uName;
@@ -19,8 +21,24 @@ public class NameChecker implements Listener {
     public static void onPreShopCreation(PreShopCreationEvent event) {
         String name = event.getSignLine(NAME_LINE);
         Player player = event.getPlayer();
+        boolean isBank = name.startsWith(uName.BANK_PREFIX);
+        boolean noAccess;
+        boolean exists;
+        if (isBank) {
+            name = uName.stripBankPrefix(name);
+            exists = Economy.bankExists(name);
+            noAccess = !Economy.hasBankSupport() || !Permission.has(player, Permission.BANK);
+            if (Properties.BANK_MEMBERS_ALLOWED) {
+                noAccess = noAccess || !Economy.isBankMember(player.getName(), name);
+            } else {
+                noAccess = noAccess || !Economy.isBankOwner(player.getName(), name);
+            }
+        } else {
+            noAccess = !uName.canUseName(player, name);
+            exists = Economy.hasAccount(name);
+        }
 
-        if (name.isEmpty() || (!uName.canUseName(player, name) && !Permission.has(player, Permission.ADMIN))) {
+        if (name.isEmpty() || !exists || (noAccess && !Permission.has(player, Permission.ADMIN))) {
             String shortName = uName.shortenName(player);
             event.setSignLine(NAME_LINE, shortName);
         }

--- a/src/main/java/com/Acrobot/ChestShop/Permission.java
+++ b/src/main/java/com/Acrobot/ChestShop/Permission.java
@@ -21,6 +21,7 @@ public enum Permission {
     MOD("ChestShop.mod"),
     OTHER_NAME("ChestShop.name."),
     GROUP("ChestShop.group."),
+    BANK("ChestShop.bank"),
 
     NOFEE("ChestShop.nofee"),
     DISCOUNT("ChestShop.discount.");

--- a/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
+++ b/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
@@ -23,7 +23,7 @@ public class ChestShopSign {
     public static final byte ITEM_LINE = 3;
 
     public static final Pattern[] SHOP_SIGN_PATTERN = {
-            Pattern.compile("^[\\w -.]*$"),
+            Pattern.compile("^(" + uName.BANK_PREFIX_QUOTED + ")?[\\w -.]*$"),
             Pattern.compile("^[1-9][0-9]*$"),
             Pattern.compile("(?i)^[\\d.bs(free) :]+$"),
             Pattern.compile("^[\\w #:-]+$")

--- a/src/main/java/com/Acrobot/ChestShop/Utils/uName.java
+++ b/src/main/java/com/Acrobot/ChestShop/Utils/uName.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * @author Acrobot
@@ -13,6 +14,10 @@ import java.io.IOException;
 public class uName {
     public static YamlConfiguration config;
     public static File file;
+
+    public static final String BANK_PREFIX = "$";
+    public static final String BANK_PREFIX_QUOTED = Pattern.quote(BANK_PREFIX);
+    public static final String BANK_PREFIX_REPLACE = "^" + BANK_PREFIX_QUOTED;
 
     public static String getName(String shortName) {
         return config.getString(shortName, shortName);
@@ -41,6 +46,10 @@ public class uName {
 
     public static boolean canUseName(Player player, String name) {
         return shortenName(player).equals(name) || Permission.otherName(player, name);
+    }
+
+    public static String stripBankPrefix(String name) {
+        return name.replaceFirst(BANK_PREFIX_REPLACE, "");
     }
 
     public static void load() {


### PR DESCRIPTION
This allows people with the ChestShop.bank permission to put $BankName on th
e first line of a ChestShop sign to indicate that the shop should be linked to t
he given bank account rather than their own account. Admins are able to link to
any account, and players only to ones they are an owner of, or, if enabled, ones
they are a member of. Seeing as the concept of bank accounts is different for R
egister, I did not enable support for bank accounts with it, as there was no obv
ious way to make it work.
