### PR TITLE
Only check if a bank exists when banks are supported

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Economy/Economy.java
+++ b/src/main/java/com/Acrobot/ChestShop/Economy/Economy.java
@@ -44,7 +44,11 @@ public class Economy {
     }
 
     public static boolean bankExists(String name) {
-        return manager.bankExists(name);
+        if (hasBankSupport()) {
+            return manager.bankExists(name);
+        } else {
+            return false;
+        }
     }
 
     public static boolean add(String name, double amount) {


### PR DESCRIPTION
Without this, an `UnsupportedOperationException` could still be thrown if iConomy 6 is being used, as `Economy.bankExists(String)` is called regardless of whether `Economy.hasBankSupport()` returns true.
