### PR TITLE
Fix for Chestshop ignoring event cancellation

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
@@ -42,7 +42,7 @@ import static org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK;
  */
 public class PlayerInteract implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public static void onInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
 


### PR DESCRIPTION
Plugin with LOWEST priority cancels the event but chestshop ignores that flag and continues anyway.
