### PR TITLE
Add shading for guava/gson for Thermos support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Shade gson and guava, as they are not included in earlier Bukkit releases -->
+        <!-- gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.7</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -291,6 +307,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                           <minimizeJar>false</minimizeJar>
                             <artifactSet>
                                 <includes>
                                     <include>org.mcstats.bukkit</include>
@@ -298,9 +315,14 @@
                                     <include>net.gravitydevelopment.updater</include>
                                     <include>com.j256.ormlite</include>
                                     <include>org.apache.logging.log4j</include>
+                                    <include>com.google.*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>com.Acrobot.shaded.google</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.mcstats</pattern>
                                     <shadedPattern>com.Acrobot.ChestShop.Metrics.MCStats</shadedPattern>


### PR DESCRIPTION
There is likely a better way to do this, as it makes the jar bigger to do this, but it shouldn't be required on the latest spigot etc