### PR TITLE
Fix Vault-Accountcheck for renamed player

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Configuration/Messages.java
+++ b/src/main/java/com/Acrobot/ChestShop/Configuration/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
     @PrecededBySpace
     public static String CLIENT_DEPOSIT_FAILED = "Money deposit to your account failed!";
     public static String SHOP_DEPOSIT_FAILED = "Money deposit to shop owner failed!";
+    public static String NO_VAULT_ACCOUNT = "Economy account from shop owner doesn't exist!";
 
     @PrecededBySpace
     public static String NO_BUYING_HERE = "You can't buy here!";

--- a/src/main/java/com/Acrobot/ChestShop/Configuration/Messages.java
+++ b/src/main/java/com/Acrobot/ChestShop/Configuration/Messages.java
@@ -20,7 +20,7 @@ public class Messages {
     @PrecededBySpace
     public static String CLIENT_DEPOSIT_FAILED = "Money deposit to your account failed!";
     public static String SHOP_DEPOSIT_FAILED = "Money deposit to shop owner failed!";
-    public static String NO_VAULT_ACCOUNT = "Economy account from shop owner doesn't exist!";
+    public static String NO_ECONOMY_ACCOUNT = "Economy account from shop owner doesn't exist!";
 
     @PrecededBySpace
     public static String NO_BUYING_HERE = "You can't buy here!";

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
@@ -18,7 +18,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.block.Sign;
@@ -140,16 +139,19 @@ public class PlayerInteract implements Listener {
         String prices = sign.getLine(PRICE_LINE);
         String material = sign.getLine(ITEM_LINE);
 
-        Account account = NameManager.getAccountFromShortName(name);
-        if (account == null)
+        Account account = NameManager.getLastAccountFromShortName(name);
+        if (account == null) {
+            player.sendMessage(Messages.prefix(Messages.PLAYER_NOT_FOUND));
             return null;
+        }
 
         boolean adminShop = ChestShopSign.isAdminShop(sign);
 
         // check if player exists in economy
-        OfflinePlayer lastSeen = Bukkit.getOfflinePlayer(account.getUuid());
-        if(!adminShop && !VaultListener.getProvider().hasAccount(lastSeen))
+        if(!adminShop && !VaultListener.getProvider().hasAccount(account.getName())) {
+            player.sendMessage(Messages.prefix(Messages.NO_VAULT_ACCOUNT));
             return null;
+        }
 
         Action buy = Properties.REVERSE_BUTTONS ? LEFT_CLICK_BLOCK : RIGHT_CLICK_BLOCK;
         double price = (action == buy ? PriceUtil.getBuyPrice(prices) : PriceUtil.getSellPrice(prices));

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
@@ -149,7 +149,7 @@ public class PlayerInteract implements Listener {
 
         // check if player exists in economy
         if(!adminShop && !VaultListener.getProvider().hasAccount(account.getName())) {
-            player.sendMessage(Messages.prefix(Messages.NO_VAULT_ACCOUNT));
+            player.sendMessage(Messages.prefix(Messages.NO_ECONOMY_ACCOUNT));
             return null;
         }
 

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
@@ -18,6 +18,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.block.Sign;
@@ -146,7 +147,8 @@ public class PlayerInteract implements Listener {
         boolean adminShop = ChestShopSign.isAdminShop(sign);
 
         // check if player exists in economy
-        if(!adminShop && !VaultListener.getProvider().hasAccount(account.getName()))
+        OfflinePlayer lastSeen = Bukkit.getOfflinePlayer(account.getUuid());
+        if(!adminShop && !VaultListener.getProvider().hasAccount(lastSeen))
             return null;
 
         Action buy = Properties.REVERSE_BUTTONS ? LEFT_CLICK_BLOCK : RIGHT_CLICK_BLOCK;


### PR DESCRIPTION
Shops of renamed players may not work anymore. The check whether an economy account exists must be made on the new account and not on the old user name that no longer exists.