### PR TITLE
Make ItemInfoEvent cancellable (to cancel /iteminfo command)

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
+++ b/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
@@ -40,7 +40,10 @@ public class ItemInfo implements CommandExecutor {
             item = parseEvent.getItem();
         }
 
-        if (MaterialUtil.isEmpty(item)) {
+        ItemInfoEvent event = new ItemInfoEvent(sender, item);
+        ChestShop.callEvent(event);
+
+        if (event.isCancelled() || MaterialUtil.isEmpty(item)) {
             return false;
         }
 
@@ -60,9 +63,6 @@ public class ItemInfo implements CommandExecutor {
             ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating shop sign item name", e);
             return true;
         }
-
-        ItemInfoEvent event = new ItemInfoEvent(sender, item);
-        ChestShop.callEvent(event);
 
         return true;
     }

--- a/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
+++ b/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
@@ -39,10 +39,10 @@ public class ItemInfo implements CommandExecutor {
             Bukkit.getPluginManager().callEvent(parseEvent);
             item = parseEvent.getItem();
         }
-    
+
         ItemInfoEvent event = new ItemInfoEvent(sender, item);
         ChestShop.callEvent(event);
-    
+
         return !MaterialUtil.isEmpty(item);
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
+++ b/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
@@ -43,6 +43,6 @@ public class ItemInfo implements CommandExecutor {
         ItemInfoEvent event = new ItemInfoEvent(sender, item);
         ChestShop.callEvent(event);
     
-        return !event.isCancelled() && !MaterialUtil.isEmpty(item);
+        return !MaterialUtil.isEmpty(item);
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
+++ b/src/main/java/com/Acrobot/ChestShop/Commands/ItemInfo.java
@@ -39,31 +39,10 @@ public class ItemInfo implements CommandExecutor {
             Bukkit.getPluginManager().callEvent(parseEvent);
             item = parseEvent.getItem();
         }
-
+    
         ItemInfoEvent event = new ItemInfoEvent(sender, item);
         ChestShop.callEvent(event);
-
-        if (event.isCancelled() || MaterialUtil.isEmpty(item)) {
-            return false;
-        }
-
-        iteminfo.send(sender);
-        try {
-            iteminfo_fullname.send(sender, "item", MaterialUtil.getName(item));
-        } catch (IllegalArgumentException e) {
-            sender.sendMessage(ChatColor.RED + "Error while generating full name. Please contact an admin or take a look at the console/log!");
-            ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating full item name", e);
-            return true;
-        }
-
-        try {
-            iteminfo_shopname.send(sender, "item", MaterialUtil.getSignName(item));
-        } catch (IllegalArgumentException e) {
-            sender.sendMessage(ChatColor.RED + "Error while generating shop sign name. Please contact an admin or take a look at the console/log!");
-            ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating shop sign item name", e);
-            return true;
-        }
-
-        return true;
+    
+        return !event.isCancelled() && !MaterialUtil.isEmpty(item);
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Events/ItemInfoEvent.java
+++ b/src/main/java/com/Acrobot/ChestShop/Events/ItemInfoEvent.java
@@ -1,6 +1,7 @@
 package com.Acrobot.ChestShop.Events;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
@@ -10,15 +11,17 @@ import org.bukkit.inventory.ItemStack;
  *
  * @author Acrobot
  */
-public class ItemInfoEvent extends Event {
+public class ItemInfoEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     private CommandSender sender;
     private ItemStack item;
+    private boolean cancelled;
 
     public ItemInfoEvent(CommandSender sender, ItemStack item) {
         this.sender = sender;
         this.item = item;
+        this.cancelled = false;
     }
 
     /**
@@ -41,5 +44,15 @@ public class ItemInfoEvent extends Event {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+    
+    @Override
+    public boolean isCancelled () {
+        return cancelled;
+    }
+    
+    @Override
+    public void setCancelled (boolean b) {
+        cancelled = b;
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -31,8 +31,8 @@ import static com.Acrobot.ChestShop.Configuration.Messages.iteminfo_repaircost;
  */
 public class ItemInfoListener implements Listener {
     
-    @EventHandler(priority =  EventPriority.LOW)
-    public static void messageSender (ItemInfoEvent event) {
+    @EventHandler(priority =  EventPriority.LOW, ignoreCancelled = true)
+    public static void messageHandler (ItemInfoEvent event) {
         CommandSender sender = event.getSender();
         ItemStack item = event.getItem();
         iteminfo.send(sender);
@@ -51,93 +51,87 @@ public class ItemInfoListener implements Listener {
             ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating shop sign item name", e);
         }
     }
-
-    @EventHandler
-    public static void addRepairCost(ItemInfoEvent event) {
+    
+    @EventHandler(ignoreCancelled = true)
+    public static void addRepairCost (ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta instanceof Repairable && ((Repairable) meta).getRepairCost() > 0) {
             iteminfo_repaircost.send(event.getSender(), "cost", String.valueOf(((Repairable) meta).getRepairCost()));
         }
     }
-
-    @EventHandler
-    public static void addEnchantment(ItemInfoEvent event) {
+    
+    @EventHandler(ignoreCancelled = true)
+    public static void addEnchantment (ItemInfoEvent event) {
         ItemStack item = event.getItem();
         ItemMeta meta = item.getItemMeta();
         CommandSender sender = event.getSender();
-
+        
         for (Map.Entry<Enchantment, Integer> enchantment : item.getEnchantments().entrySet()) {
             sender.sendMessage(ChatColor.AQUA + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
         }
-
+        
         if (meta instanceof EnchantmentStorageMeta) {
             for (Map.Entry<Enchantment, Integer> enchantment : ((EnchantmentStorageMeta) meta).getStoredEnchants().entrySet()) {
                 sender.sendMessage(ChatColor.YELLOW + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
             }
         }
     }
-
-    @EventHandler
-    public static void addPotionInfo(ItemInfoEvent event) {
+    
+    @EventHandler(ignoreCancelled = true)
+    public static void addPotionInfo (ItemInfoEvent event) {
         ItemStack item = event.getItem();
-
+        
         if (item.getType() != Material.POTION || item.getDurability() == 0) {
             return;
         }
-
+        
         Potion potion;
-
+        
         try {
             potion = Potion.fromItemStack(item);
         } catch (IllegalArgumentException ex) {
             return;
         }
-
+        
         StringBuilder message = new StringBuilder(50);
-
+        
         message.append(ChatColor.GRAY);
-
+        
         if (potion.getType() == null) {
             return;
         }
-
+        
         if (potion.isSplash()) {
             message.append("Splash ");
         }
-
+        
         message.append("Potion of ");
         message.append(capitalizeFirstLetter(potion.getType().name(), '_')).append(' ');
         message.append(toRoman(potion.getLevel()));
-
+        
         CommandSender sender = event.getSender();
-
+        
         sender.sendMessage(message.toString());
-
+        
         for (PotionEffect effect : potion.getEffects()) {
             sender.sendMessage(ChatColor.DARK_GRAY + capitalizeFirstLetter(effect.getType().getName(), '_') + ' ' + toTime(effect.getDuration() / 20));
         }
     }
-
-    @EventHandler
-    public static void addBookInfo(ItemInfoEvent event) {
+    
+    @EventHandler(ignoreCancelled = true)
+    public static void addBookInfo (ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta instanceof BookMeta) {
             BookMeta book = (BookMeta) meta;
-            iteminfo_book.send(event.getSender(),
-                    "title", book.getTitle(),
-                    "author", book.getAuthor(),
-                    "pages", String.valueOf(book.getPageCount())
-            );
+            iteminfo_book.send(event.getSender(), "title", book.getTitle(), "author", book.getAuthor(), "pages", String.valueOf(book.getPageCount()));
             if (book.hasGeneration()) {
-                iteminfo_book_generation.send(event.getSender(),
-                        "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_')
-                );
+                iteminfo_book_generation.send(event.getSender(), "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_'));
             }
         }
     }
-
-    @EventHandler
-    public static void addLoreInfo(ItemInfoEvent event) {
+    
+    @EventHandler(ignoreCancelled = true)
+    public static void addLoreInfo (ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta.hasLore()) {
             iteminfo_lore.send(event.getSender(), "lore", String.join("\n", meta.getLore()));

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -30,6 +30,27 @@ import static com.Acrobot.ChestShop.Configuration.Messages.iteminfo_repaircost;
  * @author Acrobot
  */
 public class ItemInfoListener implements Listener {
+    
+    @EventHandler(priority =  EventPriority.LOW)
+    public static void messageSender (ItemInfoEvent event) {
+        CommandSender sender = event.getSender();
+        ItemStack item = event.getItem();
+        iteminfo.send(sender);
+        try {
+            iteminfo_fullname.send(sender, "item", MaterialUtil.getName(item));
+        } catch (IllegalArgumentException e) {
+            event.getSender().sendMessage(ChatColor.RED + "Error while generating full name. Please contact an admin or take a look at the console/log!");
+            ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating full item name", e);
+            return;
+        }
+        
+        try {
+            iteminfo_shopname.send(sender, "item", MaterialUtil.getSignName(item));
+        } catch (IllegalArgumentException e) {
+            sender.sendMessage(ChatColor.RED + "Error while generating shop sign name. Please contact an admin or take a look at the console/log!");
+            ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating shop sign item name", e);
+        }
+    }
 
     @EventHandler
     public static void addRepairCost(ItemInfoEvent event) {

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -43,7 +43,7 @@ public class ItemInfoListener implements Listener {
             ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating full item name", e);
             return;
         }
-    
+
         try {
             iteminfo_shopname.send(sender, "item", MaterialUtil.getSignName(item));
         } catch (IllegalArgumentException e) {
@@ -65,11 +65,11 @@ public class ItemInfoListener implements Listener {
         ItemStack item = event.getItem();
         ItemMeta meta = item.getItemMeta();
         CommandSender sender = event.getSender();
-    
+
         for (Map.Entry<Enchantment, Integer> enchantment : item.getEnchantments().entrySet()) {
             sender.sendMessage(ChatColor.AQUA + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
         }
-    
+
         if (meta instanceof EnchantmentStorageMeta) {
             for (Map.Entry<Enchantment, Integer> enchantment : ((EnchantmentStorageMeta) meta).getStoredEnchants().entrySet()) {
                 sender.sendMessage(ChatColor.YELLOW + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
@@ -80,39 +80,39 @@ public class ItemInfoListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public static void addPotionInfo(ItemInfoEvent event) {
         ItemStack item = event.getItem();
-    
+
         if (item.getType() != Material.POTION || item.getDurability() == 0) {
             return;
         }
-    
+
         Potion potion;
-    
+
         try {
             potion = Potion.fromItemStack(item);
         } catch (IllegalArgumentException ex) {
             return;
         }
-    
+
         StringBuilder message = new StringBuilder(50);
-    
+
         message.append(ChatColor.GRAY);
-    
+
         if (potion.getType() == null) {
             return;
         }
-    
+
         if (potion.isSplash()) {
             message.append("Splash ");
         }
-    
+
         message.append("Potion of ");
         message.append(capitalizeFirstLetter(potion.getType().name(), '_')).append(' ');
         message.append(toRoman(potion.getLevel()));
-    
+
         CommandSender sender = event.getSender();
-    
+
         sender.sendMessage(message.toString());
-    
+
         for (PotionEffect effect : potion.getEffects()) {
             sender.sendMessage(ChatColor.DARK_GRAY + capitalizeFirstLetter(effect.getType().getName(), '_') + ' ' + toTime(effect.getDuration() / 20));
         }
@@ -123,9 +123,15 @@ public class ItemInfoListener implements Listener {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta instanceof BookMeta) {
             BookMeta book = (BookMeta) meta;
-            iteminfo_book.send(event.getSender(), "title", book.getTitle(), "author", book.getAuthor(), "pages", String.valueOf(book.getPageCount()));
+            iteminfo_book.send(event.getSender(),
+                               "title", book.getTitle(),
+                               "author", book.getAuthor(),
+                               "pages", String.valueOf(book.getPageCount())
+            );
             if (book.hasGeneration()) {
-                iteminfo_book_generation.send(event.getSender(), "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_'));
+                iteminfo_book_generation.send(event.getSender(),
+                                              "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_')
+                );
             }
         }
     }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -30,9 +30,9 @@ import static com.Acrobot.ChestShop.Configuration.Messages.iteminfo_repaircost;
  * @author Acrobot
  */
 public class ItemInfoListener implements Listener {
-    
+
     @EventHandler(priority =  EventPriority.LOW, ignoreCancelled = true)
-    public static void messageHandler (ItemInfoEvent event) {
+    public static void messageHandler(ItemInfoEvent event) {
         CommandSender sender = event.getSender();
         ItemStack item = event.getItem();
         iteminfo.send(sender);
@@ -51,17 +51,17 @@ public class ItemInfoListener implements Listener {
             ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating shop sign item name", e);
         }
     }
-    
+
     @EventHandler(ignoreCancelled = true)
-    public static void addRepairCost (ItemInfoEvent event) {
+    public static void addRepairCost(ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta instanceof Repairable && ((Repairable) meta).getRepairCost() > 0) {
             iteminfo_repaircost.send(event.getSender(), "cost", String.valueOf(((Repairable) meta).getRepairCost()));
         }
     }
-    
+
     @EventHandler(ignoreCancelled = true)
-    public static void addEnchantment (ItemInfoEvent event) {
+    public static void addEnchantment(ItemInfoEvent event) {
         ItemStack item = event.getItem();
         ItemMeta meta = item.getItemMeta();
         CommandSender sender = event.getSender();
@@ -76,9 +76,9 @@ public class ItemInfoListener implements Listener {
             }
         }
     }
-    
+
     @EventHandler(ignoreCancelled = true)
-    public static void addPotionInfo (ItemInfoEvent event) {
+    public static void addPotionInfo(ItemInfoEvent event) {
         ItemStack item = event.getItem();
         
         if (item.getType() != Material.POTION || item.getDurability() == 0) {
@@ -117,9 +117,9 @@ public class ItemInfoListener implements Listener {
             sender.sendMessage(ChatColor.DARK_GRAY + capitalizeFirstLetter(effect.getType().getName(), '_') + ' ' + toTime(effect.getDuration() / 20));
         }
     }
-    
+
     @EventHandler(ignoreCancelled = true)
-    public static void addBookInfo (ItemInfoEvent event) {
+    public static void addBookInfo(ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta instanceof BookMeta) {
             BookMeta book = (BookMeta) meta;
@@ -129,9 +129,9 @@ public class ItemInfoListener implements Listener {
             }
         }
     }
-    
+
     @EventHandler(ignoreCancelled = true)
-    public static void addLoreInfo (ItemInfoEvent event) {
+    public static void addLoreInfo(ItemInfoEvent event) {
         ItemMeta meta = event.getItem().getItemMeta();
         if (meta.hasLore()) {
             iteminfo_lore.send(event.getSender(), "lore", String.join("\n", meta.getLore()));

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -43,7 +43,7 @@ public class ItemInfoListener implements Listener {
             ChestShop.getPlugin().getLogger().log(Level.SEVERE, "Error while generating full item name", e);
             return;
         }
-        
+    
         try {
             iteminfo_shopname.send(sender, "item", MaterialUtil.getSignName(item));
         } catch (IllegalArgumentException e) {
@@ -65,11 +65,11 @@ public class ItemInfoListener implements Listener {
         ItemStack item = event.getItem();
         ItemMeta meta = item.getItemMeta();
         CommandSender sender = event.getSender();
-        
+    
         for (Map.Entry<Enchantment, Integer> enchantment : item.getEnchantments().entrySet()) {
             sender.sendMessage(ChatColor.AQUA + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
         }
-        
+    
         if (meta instanceof EnchantmentStorageMeta) {
             for (Map.Entry<Enchantment, Integer> enchantment : ((EnchantmentStorageMeta) meta).getStoredEnchants().entrySet()) {
                 sender.sendMessage(ChatColor.YELLOW + capitalizeFirstLetter(enchantment.getKey().getName(), '_') + ' ' + toRoman(enchantment.getValue()));
@@ -80,39 +80,39 @@ public class ItemInfoListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public static void addPotionInfo(ItemInfoEvent event) {
         ItemStack item = event.getItem();
-        
+    
         if (item.getType() != Material.POTION || item.getDurability() == 0) {
             return;
         }
-        
+    
         Potion potion;
-        
+    
         try {
             potion = Potion.fromItemStack(item);
         } catch (IllegalArgumentException ex) {
             return;
         }
-        
+    
         StringBuilder message = new StringBuilder(50);
-        
+    
         message.append(ChatColor.GRAY);
-        
+    
         if (potion.getType() == null) {
             return;
         }
-        
+    
         if (potion.isSplash()) {
             message.append("Splash ");
         }
-        
+    
         message.append("Potion of ");
         message.append(capitalizeFirstLetter(potion.getType().name(), '_')).append(' ');
         message.append(toRoman(potion.getLevel()));
-        
+    
         CommandSender sender = event.getSender();
-        
+    
         sender.sendMessage(message.toString());
-        
+    
         for (PotionEffect effect : potion.getEffects()) {
             sender.sendMessage(ChatColor.DARK_GRAY + capitalizeFirstLetter(effect.getType().getName(), '_') + ' ' + toTime(effect.getDuration() / 20));
         }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/ItemInfoListener.java
@@ -124,13 +124,13 @@ public class ItemInfoListener implements Listener {
         if (meta instanceof BookMeta) {
             BookMeta book = (BookMeta) meta;
             iteminfo_book.send(event.getSender(),
-                               "title", book.getTitle(),
-                               "author", book.getAuthor(),
-                               "pages", String.valueOf(book.getPageCount())
+                    "title", book.getTitle(),
+                    "author", book.getAuthor(),
+                    "pages", String.valueOf(book.getPageCount())
             );
             if (book.hasGeneration()) {
                 iteminfo_book_generation.send(event.getSender(),
-                                              "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_')
+                        "generation", StringUtil.capitalizeFirstLetter(book.getGeneration().name(), '_')
                 );
             }
         }


### PR DESCRIPTION
Making this because I need to cancel /iteminfo depending on if the item has specific properties (e.g. custom nbt data)

Haven't been able to test but because this is so straight forward and small I don't see any way for it to cause any issues.