### PR TITLE
Implement LockettePro Support and properly handle SoftDependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,6 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
             <id>NyaaCat</id>
             <url>https://ci.nyaacat.com/maven/</url>
         </repository>
@@ -331,6 +327,7 @@
             <groupId>me.crafter.mc</groupId>
             <artifactId>lockettepro</artifactId>
             <version>2.10-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,14 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>NyaaCat</id>
+            <url>https://ci.nyaacat.com/maven/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -317,6 +325,12 @@
             <artifactId>Reserve</artifactId>
             <version>0.1.0.10</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.crafter.mc</groupId>
+            <artifactId>lockettepro</artifactId>
+            <version>2.10-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/Acrobot/ChestShop/ChestShop.java
+++ b/src/main/java/com/Acrobot/ChestShop/ChestShop.java
@@ -299,6 +299,8 @@ public class ChestShop extends JavaPlugin {
     private void registerEvents() {
         registerEvent(new com.Acrobot.ChestShop.Plugins.ChestShop()); //Chest protection
 
+        registerEvent(new Dependencies());
+        
         registerEvent(new NameManager());
 
         registerPreShopCreationEvents();

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -56,7 +56,7 @@ public class Dependencies implements Listener {
 
         for (String dependency : ChestShop.getDependencies()) {
             Plugin plugin = pluginManager.getPlugin(dependency);
-    
+
             if (plugin != null && plugin.isEnabled()) {
                 loadPlugin(dependency, plugin);
             }

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -209,7 +209,7 @@ public class Dependencies implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEnable(PluginEnableEvent event) {
         Plugin plugin = event.getPlugin();
-        if(ChestShop.getDependencies().contains(plugin.getName())) {
+        if (ChestShop.getDependencies().contains(plugin.getName())) {
             loadPlugin(plugin.getName(), plugin);
         }
     }

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -96,7 +96,6 @@ public class Dependencies implements Listener {
         try {
             dependency = Dependency.valueOf(name);
         } catch (IllegalArgumentException exception) {
-            System.out.println("FAIL: " + name);
             return;
         }
 

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -6,7 +6,10 @@ import com.Acrobot.ChestShop.Listeners.Economy.Plugins.ReserveListener;
 import com.Acrobot.ChestShop.Listeners.Economy.Plugins.VaultListener;
 import com.Acrobot.ChestShop.Plugins.*;
 import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
@@ -14,7 +17,7 @@ import org.bukkit.plugin.PluginManager;
 /**
  * @author Acrobot
  */
-public class Dependencies {
+public class Dependencies implements Listener {
 
     public static void initializePlugins() {
         PluginManager pluginManager = Bukkit.getPluginManager();
@@ -53,7 +56,7 @@ public class Dependencies {
 
         for (String dependency : ChestShop.getDependencies()) {
             Plugin plugin = pluginManager.getPlugin(dependency);
-
+    
             if (plugin != null && plugin.isEnabled()) {
                 loadPlugin(dependency, plugin);
             }
@@ -93,6 +96,7 @@ public class Dependencies {
         try {
             dependency = Dependency.valueOf(name);
         } catch (IllegalArgumentException exception) {
+            System.out.println("FAIL: " + name);
             return;
         }
 
@@ -105,6 +109,9 @@ public class Dependencies {
                 break;
             case Lockette:
                 listener = new Lockette();
+                break;
+            case LockettePro:
+                listener = new LockettePro();
                 break;
             case Deadbolt:
                 listener = new Deadbolt();
@@ -184,6 +191,7 @@ public class Dependencies {
     private static enum Dependency {
         LWC,
         Lockette,
+        LockettePro,
         Deadbolt,
         SimpleChestLock,
         Residence,
@@ -197,5 +205,13 @@ public class Dependencies {
         Heroes,
 
         ShowItem
+    }
+    
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEnable(PluginEnableEvent event) {
+        Plugin plugin = event.getPlugin();
+        if(ChestShop.getDependencies().contains(plugin.getName())) {
+            loadPlugin(plugin.getName(), plugin);
+        }
     }
 }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
@@ -55,11 +55,15 @@ public class SignCreate implements Listener {
         for (byte i = 0; i < preEvent.getSignLines().length && i < 4; ++i) {
             event.setLine(i, preEvent.getSignLine(i));
         }
-
+    
+        System.out.println(preEvent.getOutcome());
+        
         if (preEvent.isCancelled()) {
             return;
         }
-
+    
+        System.out.println("TEST HERE");
+        
         ShopCreatedEvent postEvent = new ShopCreatedEvent(preEvent.getPlayer(), preEvent.getSign(), uBlock.findConnectedContainer(preEvent.getSign()), preEvent.getSignLines(), preEvent.getOwnerAccount());
         ChestShop.callEvent(postEvent);
     }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
@@ -56,14 +56,10 @@ public class SignCreate implements Listener {
             event.setLine(i, preEvent.getSignLine(i));
         }
     
-        System.out.println(preEvent.getOutcome());
-        
         if (preEvent.isCancelled()) {
             return;
         }
     
-        System.out.println("TEST HERE");
-        
         ShopCreatedEvent postEvent = new ShopCreatedEvent(preEvent.getPlayer(), preEvent.getSign(), uBlock.findConnectedContainer(preEvent.getSign()), preEvent.getSignLines(), preEvent.getOwnerAccount());
         ChestShop.callEvent(postEvent);
     }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Block/SignCreate.java
@@ -55,11 +55,11 @@ public class SignCreate implements Listener {
         for (byte i = 0; i < preEvent.getSignLines().length && i < 4; ++i) {
             event.setLine(i, preEvent.getSignLine(i));
         }
-    
+
         if (preEvent.isCancelled()) {
             return;
         }
-    
+
         ShopCreatedEvent postEvent = new ShopCreatedEvent(preEvent.getPlayer(), preEvent.getSign(), uBlock.findConnectedContainer(preEvent.getSign()), preEvent.getSignLines(), preEvent.getOwnerAccount());
         ChestShop.callEvent(postEvent);
     }

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Player/PlayerInteract.java
@@ -20,6 +20,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
@@ -275,6 +276,10 @@ public class PlayerInteract implements Listener {
         }
 
         if (!Security.canAccess(player, signBlock)) {
+            return;
+        }
+        
+        if (!Security.canAccess(player, container.getBlock())) {
             return;
         }
 

--- a/src/main/java/com/Acrobot/ChestShop/Plugins/LockettePro.java
+++ b/src/main/java/com/Acrobot/ChestShop/Plugins/LockettePro.java
@@ -1,0 +1,30 @@
+package com.Acrobot.ChestShop.Plugins;
+
+import com.Acrobot.ChestShop.Events.Protection.ProtectionCheckEvent;
+import me.crafter.mc.lockettepro.LocketteProAPI;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class LockettePro implements Listener {
+	
+	@EventHandler
+	public static void onProtectionCheck(ProtectionCheckEvent event) {
+		if (event.getResult() == Event.Result.DENY) {
+			return;
+		}
+		
+		Player player = event.getPlayer();
+		Block block = event.getBlock();
+		
+		if (!LocketteProAPI.isProtected(block)) {
+			return;
+		}
+		
+		if (LocketteProAPI.isLocked(block) && !LocketteProAPI.isOwner(block, player)) {
+			event.setResult(Event.Result.DENY);
+		}
+	}
+}

--- a/src/main/java/com/Acrobot/ChestShop/Plugins/LockettePro.java
+++ b/src/main/java/com/Acrobot/ChestShop/Plugins/LockettePro.java
@@ -9,22 +9,22 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
 public class LockettePro implements Listener {
-	
-	@EventHandler
-	public static void onProtectionCheck(ProtectionCheckEvent event) {
-		if (event.getResult() == Event.Result.DENY) {
-			return;
-		}
-		
-		Player player = event.getPlayer();
-		Block block = event.getBlock();
-		
-		if (!LocketteProAPI.isProtected(block)) {
-			return;
-		}
-		
-		if (LocketteProAPI.isLocked(block) && !LocketteProAPI.isOwner(block, player)) {
-			event.setResult(Event.Result.DENY);
-		}
-	}
+
+    @EventHandler
+    public static void onProtectionCheck(ProtectionCheckEvent event) {
+        if (event.getResult() == Event.Result.DENY) {
+            return;
+        }
+        
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        
+        if (!LocketteProAPI.isProtected(block)) {
+            return;
+        }
+        
+        if (LocketteProAPI.isLocked(block) && !LocketteProAPI.isOwner(block, player)) {
+            event.setResult(Event.Result.DENY);
+        }
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '${bukkit.plugin.version}'
 author: Acrobot
 authors: ['https://github.com/ChestShop-authors/ChestShop-3/contributors']
 description: A chest shop for economy plugins.
-softdepend: [Vault, Reserve, LWC, Lockette, Deadbolt, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem]
+softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem]
 api-version: '1.13'
 
 commands:


### PR DESCRIPTION
This pull request aims to provide a support for LockettePro (latest in 1.15.2+ for Lockette).
This also aims to achieve soft dependency handling a bit better.

Soft dependencies have no responsibility or guarantee to load or enable before the plugin even if it is a soft dependency. It will try to but there is no solid guarantee. Implementing plugin dependencies on the enable event may increase boot times by ~1ms but I think that's a fair trade-off for assurance that protection plugins and other supporting hooks are able to work with ChestShop.