### PR TITLE
Add support for BlockLocker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,13 @@
         </dependency>
 
         <dependency>
+            <groupId>nl.rutgerkok</groupId>
+            <artifactId>blocklocker</artifactId>
+            <version>1.9</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.bekvon.bukkit</groupId>
             <artifactId>residence</artifactId>
             <version>4.6.1.4</version>

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -118,6 +118,9 @@ public class Dependencies implements Listener {
             case SimpleChestLock:
                 listener = SimpleChestLock.getSimpleChestLock(plugin);
                 break;
+            case BlockLocker:
+                listener = new BlockLocker();
+                break;
             case Residence:
                 if (plugin.getDescription().getVersion().startsWith("2")) {
                     ChestShop.getBukkitLogger().severe("You are using an old version of Residence! " +
@@ -190,6 +193,7 @@ public class Dependencies implements Listener {
         LockettePro,
         Deadbolt,
         SimpleChestLock,
+        BlockLocker,
         Residence,
 
         WorldGuard,

--- a/src/main/java/com/Acrobot/ChestShop/Plugins/BlockLocker.java
+++ b/src/main/java/com/Acrobot/ChestShop/Plugins/BlockLocker.java
@@ -1,0 +1,29 @@
+package com.Acrobot.ChestShop.Plugins;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.Acrobot.ChestShop.Events.Protection.ProtectionCheckEvent;
+
+import nl.rutgerkok.blocklocker.BlockLockerAPIv2;
+
+/**
+ * @author Acrobot
+ */
+public class BlockLocker implements Listener {
+
+
+    @EventHandler
+    public void onProtectionCheck(ProtectionCheckEvent event) {
+        if (event.getResult() == Event.Result.DENY) {
+            return;
+        }
+
+        Block block = event.getBlock();
+        if (BlockLockerAPIv2.isProtected(block) && !BlockLockerAPIv2.isOwner(event.getPlayer(), block)) {
+            event.setResult(Event.Result.DENY);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '${bukkit.plugin.version}'
 author: Acrobot
 authors: ['https://github.com/ChestShop-authors/ChestShop-3/contributors']
 description: A chest shop for economy plugins.
-softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem]
+softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, BlockLocker, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem]
 api-version: '1.13'
 
 commands:


### PR DESCRIPTION
BlockLocker is a plugin that I've written that allows you to lock chests using a sign with [Private] on it. The plugin is a clone of Lockette. Currently, it's the only surviving clone.

If someone protects a chest using BlockLocker, then people can no longer steal items. However, there's one clever loophole that uses ChestShop: you can turn the chest into a shop. For similar chest locking plugins (Lockette, LockettePro, LWC, Deadbolt), ChestShop has patched this.

This pull request therefore adds support for BlockLocker, so that people can no longer steal items from a protected chest by opening a shop.

## Implementation details
The code is adapted from the Lockette bridge. Besides updating some config files and initialization code, the main change is this:

 ```java
    @EventHandler
    public void onProtectionCheck(ProtectionCheckEvent event) {
        if (event.getResult() == Event.Result.DENY) {
            return;
        }

        Block block = event.getBlock();
        if (BlockLockerAPIv2.isProtected(block) && !BlockLockerAPIv2.isOwner(event.getPlayer(), block)) {
            event.setResult(Event.Result.DENY);
        }
    }
```

BlockLocker has been added to the POM file. Maven will automatically download it from CodeMC.

## Testing
I've done some simple testing: I downloaded version 3.11 from BukkitDev and verified that people could open a shop on someone else's protected chest. Then, I compiled my build and verified that shops could indeed no longer be created on these chests. Shops could still be created on a chest that was not protected, or that was protected by yourself.

I've also verified that BlockLocker isn't accidentally shaded into the plugin JAR of ChestShop.
