### PR TITLE
Make Unicode character valid in ChestShop Sign

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
+++ b/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
@@ -43,7 +43,7 @@ public class ChestShopSign {
                 Pattern.compile("(?i)^(((\\d*([.e]\\d+)?)|free) *[BS]) *: *(((\\d*([.e]\\d+)?)|free) *[BS])$"),
                 Pattern.compile("(?i)^([BS] *((\\d*([.e]\\d+)?)|free)) *: *(((\\d*([.e]\\d+)?)|free) *[BS])$"),
             },
-            { Pattern.compile("^[\\w? #:\\-]+$") }
+            { Pattern.compile("^[\\p{L}? #:\\-]+$") }
     };
     public static final String AUTOFILL_CODE = "?";
 


### PR DESCRIPTION
When I use itemAlias.yml
If the alias contains special character, the ChestShop sign won't be valid.
This PR fix this