### PR TITLE
Trigger transaction message from CurrencyTransferEvent and consider tax

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Events/Economy/CurrencyTransferEvent.java
+++ b/src/main/java/com/Acrobot/ChestShop/Events/Economy/CurrencyTransferEvent.java
@@ -1,5 +1,6 @@
 package com.Acrobot.ChestShop.Events.Economy;
 
+import com.Acrobot.ChestShop.Events.TransactionEvent;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -25,26 +26,32 @@ public class CurrencyTransferEvent extends EconomicEvent {
 
     private Direction direction;
 
+    private final TransactionEvent transactionEvent;
+
     public CurrencyTransferEvent(BigDecimal amount, Player initiator, UUID partner, Direction direction) {
         this(amount, amount, initiator, partner, direction);
     }
 
     public CurrencyTransferEvent(BigDecimal amountSent, BigDecimal amountReceived, Player initiator, UUID partner, Direction direction) {
+        this(amountSent, amountReceived, initiator, partner, direction, null);
+    }
+
+
+    public CurrencyTransferEvent(BigDecimal amount, Player initiator, UUID partner, Direction direction, TransactionEvent transactionEvent) {
+        this(amount, amount, initiator, partner, direction, transactionEvent);
+    }
+
+    public CurrencyTransferEvent(BigDecimal amountSent, BigDecimal amountReceived, Player initiator, UUID partner, Direction direction, TransactionEvent transactionEvent) {
         this.amountSent = amountSent;
         this.amountReceived = amountReceived;
         this.initiator = initiator;
 
         this.partner = partner;
         this.direction = direction;
+
+        this.transactionEvent = transactionEvent;
     }
 
-    /**
-     * @deprecated Use {{@link #CurrencyTransferEvent(BigDecimal, Player, UUID, Direction)}
-     */
-    @Deprecated
-    public CurrencyTransferEvent(double amount, Player initiator, UUID partner, Direction direction) {
-        this(BigDecimal.valueOf(amount), initiator, partner, direction);
-    }
 
     /**
      * @return Amount of currency sent
@@ -148,6 +155,15 @@ public class CurrencyTransferEvent extends EconomicEvent {
      */
     public Direction getDirection() {
         return direction;
+    }
+
+    /**
+     * Gets the {@link TransactionEvent} associated with this currency transfer event.
+     *
+     * @return the transaction event.
+     */
+    public TransactionEvent getTransactionEvent() {
+        return transactionEvent;
     }
 
     /**

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Economy/ServerAccountCorrector.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Economy/ServerAccountCorrector.java
@@ -80,7 +80,8 @@ public class ServerAccountCorrector implements Listener {
                 event.getAmountReceived(),
                 event.getInitiator(),
                 partner,
-                event.getDirection()
+                event.getDirection(),
+                event.getTransactionEvent()
         );
         ChestShop.callEvent(currencyTransferEvent);
         event.setHandled(currencyTransferEvent.wasHandled());

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/PostTransaction/EconomicModule.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/PostTransaction/EconomicModule.java
@@ -19,7 +19,8 @@ public class EconomicModule implements Listener {
                 event.getExactPrice(),
                 event.getClient(),
                 event.getOwnerAccount().getUuid(),
-                event.getTransactionType() == BUY ? CurrencyTransferEvent.Direction.PARTNER : CurrencyTransferEvent.Direction.INITIATOR
+                event.getTransactionType() == BUY ? CurrencyTransferEvent.Direction.PARTNER : CurrencyTransferEvent.Direction.INITIATOR,
+                event
         );
         ChestShop.callEvent(currencyTransferEvent);
         if (!currencyTransferEvent.wasHandled()) {

--- a/src/main/java/com/Acrobot/ChestShop/Listeners/PostTransaction/TransactionMessageSender.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/PostTransaction/TransactionMessageSender.java
@@ -6,6 +6,7 @@ import com.Acrobot.ChestShop.Commands.Toggle;
 import com.Acrobot.ChestShop.Configuration.Messages;
 import com.Acrobot.ChestShop.Configuration.Properties;
 import com.Acrobot.ChestShop.Economy.Economy;
+import com.Acrobot.ChestShop.Events.Economy.CurrencyTransferEvent;
 import com.Acrobot.ChestShop.Events.TransactionEvent;
 import com.Acrobot.ChestShop.Utils.ItemUtil;
 import org.bukkit.Bukkit;
@@ -15,6 +16,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -23,65 +25,87 @@ import java.util.Map;
  */
 public class TransactionMessageSender implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public static void onTransaction(TransactionEvent event) {
-        if (event.getTransactionType() == TransactionEvent.TransactionType.BUY) {
+    public static void onCurrencyTransfer(CurrencyTransferEvent event) {
+        if (event.getTransactionEvent() == null) {
+            return;
+        }
+        if (event.getTransactionEvent().getTransactionType() == TransactionEvent.TransactionType.BUY) {
             sendBuyMessage(event);
         } else {
             sendSellMessage(event);
         }
     }
 
-    protected static void sendBuyMessage(TransactionEvent event) {
-        Player player = event.getClient();
+    protected static void sendBuyMessage(CurrencyTransferEvent event) {
+        TransactionEvent transactionEvent = event.getTransactionEvent();
+        Player player = transactionEvent.getClient();
 
         if (Properties.SHOW_TRANSACTION_INFORMATION_CLIENT) {
-            sendMessage(player, event.getClient().getName(), Messages.YOU_BOUGHT_FROM_SHOP, event, "owner", event.getOwnerAccount().getName());
+            sendMessage(player, transactionEvent.getClient().getName(), Messages.YOU_BOUGHT_FROM_SHOP, event, MessageTarget.BUYER, "owner", transactionEvent.getOwnerAccount().getName());
         }
 
-        if (Properties.SHOW_TRANSACTION_INFORMATION_OWNER && !Toggle.isIgnoring(event.getOwnerAccount().getUuid())) {
-            Player owner = Bukkit.getPlayer(event.getOwnerAccount().getUuid());
-            sendMessage(owner, event.getOwnerAccount().getName(), Messages.SOMEBODY_BOUGHT_FROM_YOUR_SHOP, event, "buyer", player.getName());
+        if (Properties.SHOW_TRANSACTION_INFORMATION_OWNER && !Toggle.isIgnoring(transactionEvent.getOwnerAccount().getUuid())) {
+            Player owner = Bukkit.getPlayer(transactionEvent.getOwnerAccount().getUuid());
+            sendMessage(owner, transactionEvent.getOwnerAccount().getName(), Messages.SOMEBODY_BOUGHT_FROM_YOUR_SHOP, event, MessageTarget.SELLER, "buyer", player.getName());
         }
     }
-    
-    protected static void sendSellMessage(TransactionEvent event) {
-        Player player = event.getClient();
+
+    protected static void sendSellMessage(CurrencyTransferEvent event) {
+        TransactionEvent transactionEvent = event.getTransactionEvent();
+        Player player = transactionEvent.getClient();
 
         if (Properties.SHOW_TRANSACTION_INFORMATION_CLIENT) {
-            sendMessage(player, event.getClient().getName(), Messages.YOU_SOLD_TO_SHOP, event, "buyer", event.getOwnerAccount().getName());
+            sendMessage(player, transactionEvent.getClient().getName(), Messages.YOU_SOLD_TO_SHOP, event, MessageTarget.SELLER, "buyer", transactionEvent.getOwnerAccount().getName());
         }
 
-        if (Properties.SHOW_TRANSACTION_INFORMATION_OWNER && !Toggle.isIgnoring(event.getOwnerAccount().getUuid())) {
-            Player owner = Bukkit.getPlayer(event.getOwnerAccount().getUuid());
-            sendMessage(owner, event.getOwnerAccount().getName(), Messages.SOMEBODY_SOLD_TO_YOUR_SHOP, event, "seller", player.getName());
+        if (Properties.SHOW_TRANSACTION_INFORMATION_OWNER && !Toggle.isIgnoring(transactionEvent.getOwnerAccount().getUuid())) {
+            Player owner = Bukkit.getPlayer(transactionEvent.getOwnerAccount().getUuid());
+            sendMessage(owner, transactionEvent.getOwnerAccount().getName(), Messages.SOMEBODY_SOLD_TO_YOUR_SHOP, event, MessageTarget.BUYER, "seller", player.getName());
         }
     }
-    
-    private static void sendMessage(Player player, String playerName, Messages.Message rawMessage, TransactionEvent event, String... replacements) {
-        Location loc = event.getSign().getLocation();
+
+    private static void sendMessage(Player player, String playerName, Messages.Message rawMessage, CurrencyTransferEvent event, MessageTarget messageTarget, String... replacements) {
+        TransactionEvent transactionEvent = event.getTransactionEvent();
+
+        BigDecimal actualAmount = getTransactionActualAmount(event, messageTarget);
+
+        Location loc = transactionEvent.getSign().getLocation();
         Map<String, String> replacementMap = new LinkedHashMap<>();
-        replacementMap.put("price", Economy.formatBalance(event.getExactPrice()));
+        replacementMap.put("price", Economy.formatBalance(actualAmount));
         replacementMap.put("world", loc.getWorld().getName());
         replacementMap.put("x", String.valueOf(loc.getBlockX()));
         replacementMap.put("y", String.valueOf(loc.getBlockY()));
         replacementMap.put("z", String.valueOf(loc.getBlockZ()));
         replacementMap.put("material", "%item");
-        
-        for (int i = 0; i + 1 < replacements.length; i+=2) {
+
+        for (int i = 0; i + 1 < replacements.length; i += 2) {
             replacementMap.put(replacements[i], replacements[i + 1]);
         }
 
-        if (Properties.SHOWITEM_MESSAGE && MaterialUtil.Show.sendMessage(player, playerName, rawMessage, event.getStock(), replacementMap)) {
+        if (Properties.SHOWITEM_MESSAGE && MaterialUtil.Show.sendMessage(player, playerName, rawMessage, transactionEvent.getStock(), replacementMap)) {
             return;
         }
 
         if (player != null) {
-            replacementMap.put("item", ItemUtil.getItemList(event.getStock()));
+            replacementMap.put("item", ItemUtil.getItemList(transactionEvent.getStock()));
             rawMessage.sendWithPrefix(player, replacementMap);
         } else if (playerName != null) {
-            replacementMap.put("item", ItemUtil.getItemList(event.getStock()));
+            replacementMap.put("item", ItemUtil.getItemList(transactionEvent.getStock()));
             ChestShop.sendBungeeMessage(playerName, rawMessage, replacementMap);
         }
+    }
+
+    private static BigDecimal getTransactionActualAmount(CurrencyTransferEvent event, MessageTarget messageTarget) {
+        if (messageTarget == MessageTarget.SELLER) {
+            return event.getAmountReceived();
+        } else {
+            return event.getAmountSent();
+        }
+    }
+
+    private enum MessageTarget {
+        BUYER,
+        SELLER
     }
 
 }


### PR DESCRIPTION
## Changes
* Change trigger of `TransactionMessageSender` to be from a `CurrencyTransferEvent`, instead of `TransactionEvent` (which creates it)
* Wrap original `TransactionEvent` inside of `CurrencyTransferEvent`
* Use amounts from `TransactionEvent` (which considers tax) on the message, depending on whether the player is the buyer or seller
* Remove deprecated `CurrencyTransferEvent` constructor

## Test
Ran `mvn clean install` and used the plugin on a local Spigot server.

Created a shop with a product for $5k, and a defined tax of 10%.  
### Case 1: tax applies (for both users)

* Buy mode - customer (buyer) pays $5k, shop owner (seller) receives $4.5k
* Sell mode - shop owner (buyer) pays $5k, customer (seller) receives $4.5k

### Case 2: NoTax permissions apply (for both users)

* Buy mode - customer (buyer) pays $4.5k, shop owner (seller) receives $4.5k
  * This is the logic from `TaxModule#onCurrencyTransfer` where it "reduces paid amount as the buyer has permission to not pay taxes"
* Sell mode - shop owner (seller) pays $5k, customer (seller) receives $5k
