### PR TITLE
Fix ItemAlias

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemStringListener.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemStringListener.java
@@ -11,7 +11,7 @@ public class ItemStringListener implements Listener {
     @EventHandler(priority = EventPriority.NORMAL)
     public static void calculateItemString(ItemStringQueryEvent event) {
         if (event.getItemString() == null) {
-            event.setItemString(MaterialUtil.getName(event.getItem(), event.getMaxWidth()));
+            event.setItemString(MaterialUtil.getName(event.getItem()));
         }
     }
 


### PR DESCRIPTION
Since ItemUtil already performs MaxWidth handling, and the full length key is needed for ItemAliasModule, remove MaxWidth from ItemStringListener.