### PR TITLE
Fix unexpected exception in ItemDatabase update

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Metadata/ItemDatabase.java
+++ b/src/main/java/com/Acrobot/ChestShop/Metadata/ItemDatabase.java
@@ -103,11 +103,11 @@ public class ItemDatabase {
                                 item.setBase64ItemCode(Base64.encodeObject(yaml.dump(itemStack)));
                                 itemDao.update(item);
                                 updated.getAndIncrement();
-                            } catch (YAMLException e) {
+                            } catch (YAMLException | ClassCastException e) {
                                 ChestShop.getBukkitLogger().log(Level.SEVERE, "YAML of the item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ") is corrupted: \n" + serialized);
                             }
                         }
-                    } catch (IOException | ClassNotFoundException | SQLException | ClassCastException e) {
+                    } catch (IOException | ClassNotFoundException | SQLException e) {
                         ChestShop.getBukkitLogger().log(Level.SEVERE, "Unable to convert item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ")", e);
                     } catch (StackOverflowError e) {
                         ChestShop.getBukkitLogger().log(Level.SEVERE, "Item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ") is corrupted. Sorry :(");

--- a/src/main/java/com/Acrobot/ChestShop/Metadata/ItemDatabase.java
+++ b/src/main/java/com/Acrobot/ChestShop/Metadata/ItemDatabase.java
@@ -107,7 +107,7 @@ public class ItemDatabase {
                                 ChestShop.getBukkitLogger().log(Level.SEVERE, "YAML of the item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ") is corrupted: \n" + serialized);
                             }
                         }
-                    } catch (IOException | ClassNotFoundException | SQLException e) {
+                    } catch (IOException | ClassNotFoundException | SQLException | ClassCastException e) {
                         ChestShop.getBukkitLogger().log(Level.SEVERE, "Unable to convert item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ")", e);
                     } catch (StackOverflowError e) {
                         ChestShop.getBukkitLogger().log(Level.SEVERE, "Item with ID " + Base62.encode(item.getId()) + " (" + item.getId() + ") is corrupted. Sorry :(");


### PR DESCRIPTION
After some update of ChestShop i noticed a stacktrace from ChestShop in the server logs.

Looks like my database has a lots of corrupted items but as long as most items can be updated I'm fine with that. In my case the item is corrupted and can't be deserialized, which results in some uncatched ClassCastException.

My fix is to add this exception to the catch block.


```
[17:47:22] [Server thread/ERROR]: [ChestShop] YAML of the item with ID c (12) is corrupted: 
==: org.bukkit.inventory.ItemStack
type: EXP_BOTTLE
meta: &id001
  ==: *id001
  meta-type: UNSPECIFIC
  display-name: Bottle of Wisdom

[17:47:22] [Server thread/ERROR]: [ChestShop] YAML of the item with ID d (13) is corrupted: 
&id001
==: *id001
type: EXP_BOTTLE
meta: {==: ItemMeta, meta-type: UNSPECIFIC, display-name: Bottle of Wisdom}

[17:47:22] [Server thread/ERROR]: [ChestShop] Item with ID e (14) is corrupted. Sorry :(
[17:47:22] [Server thread/ERROR]: [ChestShop] Item with ID f (15) is corrupted. Sorry :(
[17:47:22] [Server thread/ERROR]: [ChestShop] YAML of the item with ID g (16) is corrupted: 
&id001
==: org.bukkit.inventory.ItemStack
type: *id001
meta: &id002
  *id002: ItemMeta
  meta-type: UNSPECIFIC
  display-name: Bottle of Wisdom

[17:47:22] [Server thread/WARN]: java.sql.SQLException: Batch tasks callable threw non-SQL exception
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.misc.SqlExceptionUtil.create(SqlExceptionUtil.java:27)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.stmt.StatementExecutor.doCallBatchTasks(StatementExecutor.java:653)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.stmt.StatementExecutor.doCallBatchTasks(StatementExecutor.java:619)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.stmt.StatementExecutor.callBatchTasks(StatementExecutor.java:598)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.dao.BaseDaoImpl.callBatchTasks(BaseDaoImpl.java:724)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Metadata.ItemDatabase.updateMetadataVersion(ItemDatabase.java:91)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Metadata.ItemDatabase.handleMetadataUpdate(ItemDatabase.java:57)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Metadata.ItemDatabase.<init>(ItemDatabase.java:44)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.ChestShop.onEnable(ChestShop.java:144)
[17:47:22] [Server thread/WARN]: 	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:281)
[17:47:22] [Server thread/WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:189)
[17:47:22] [Server thread/WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:104)
[17:47:22] [Server thread/WARN]: 	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:507)
[17:47:22] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_20_R1.CraftServer.enablePlugin(CraftServer.java:639)
[17:47:22] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_20_R1.CraftServer.enablePlugins(CraftServer.java:550)
[17:47:22] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:636)
[17:47:22] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:435)
[17:47:22] [Server thread/WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.e(DedicatedServer.java:308)
[17:47:22] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1101)
[17:47:22] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:318)
[17:47:22] [Server thread/WARN]: 	at java.base/java.lang.Thread.run(Thread.java:833)
[17:47:22] [Server thread/WARN]: Caused by: java.lang.ClassCastException: class org.bukkit.craftbukkit.v1_20_R1.inventory.CraftMetaItem cannot be cast to class java.lang.String (org.bukkit.craftbukkit.v1_20_R1.inventory.CraftMetaItem is in unnamed module of loader java.net.URLClassLoader @2b71fc7e; java.lang.String is in module java.base of loader 'bootstrap')
[17:47:22] [Server thread/WARN]: 	at org.bukkit.configuration.serialization.ConfigurationSerialization.deserializeObject(ConfigurationSerialization.java:200)
[17:47:22] [Server thread/WARN]: 	at org.bukkit.configuration.file.YamlConstructor$ConstructCustomObject.construct(YamlConstructor.java:58)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.constructor.BaseConstructor.constructObjectNoCheck(BaseConstructor.java:264)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.constructor.BaseConstructor.constructObject(BaseConstructor.java:247)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.constructor.BaseConstructor.constructDocument(BaseConstructor.java:201)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:185)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:493)
[17:47:22] [Server thread/WARN]: 	at org.yaml.snakeyaml.Yaml.loadAs(Yaml.java:473)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Metadata.ItemDatabase.lambda$updateMetadataVersion$0(ItemDatabase.java:100)
[17:47:22] [Server thread/WARN]: 	at ChestShop.jar//com.Acrobot.ChestShop.Libs.ORMlite.stmt.StatementExecutor.doCallBatchTasks(StatementExecutor.java:649)
[17:47:22] [Server thread/WARN]: 	... 19 more
[17:47:22] [Server thread/WARN]: [ChestShop] Error while updating Item Metadata database! While the plugin will still run it will work less efficiently.
```