### PR TITLE
IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY configuration

### DIFF
--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -131,8 +131,6 @@ public class MaterialUtil {
 
         Map<String, Object> oneSerMeta = new HashMap<>(oneMeta.serialize());
         Map<String, Object> twoSerMeta = new HashMap<>(twoMeta.serialize());
-        System.out.println("IGNORE LIST: ");
-        System.out.println(Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY);
         if (!Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY.isEmpty()) {
             for (String ignoreKey : Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY) {
                 oneSerMeta.remove(ignoreKey);

--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -26,6 +26,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -33,7 +34,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.HashMap;
 
 import static com.Acrobot.Breeze.Utils.StringUtil.getMinecraftCharWidth;
 import static com.Acrobot.Breeze.Utils.StringUtil.getMinecraftStringWidth;
@@ -131,11 +131,10 @@ public class MaterialUtil {
 
         Map<String, Object> oneSerMeta = new HashMap<>(oneMeta.serialize());
         Map<String, Object> twoSerMeta = new HashMap<>(twoMeta.serialize());
-        if (!Properties.EXCLUDED_ITEM_ATTRIBUTES.isEmpty()) {
-            for (String ignoreKey : Properties.EXCLUDED_ITEM_ATTRIBUTES) {
-                oneSerMeta.remove(ignoreKey);
-                twoSerMeta.remove(ignoreKey);
-            }
+
+        for (String ignoreKey : Properties.EXCLUDED_ITEM_ATTRIBUTES) {
+            oneSerMeta.remove(ignoreKey);
+            twoSerMeta.remove(ignoreKey);
         }
 
         if (oneSerMeta.equals(twoSerMeta)) {
@@ -165,8 +164,18 @@ public class MaterialUtil {
         }
 
         ItemMeta twoDumpedMeta = twoDumped.getItemMeta();
-        if (oneDumpedMeta != null && twoDumpedMeta != null && oneDumpedMeta.serialize().equals(twoDumpedMeta.serialize())) {
-            return true;
+        if (oneDumpedMeta != null && twoDumpedMeta != null) {
+            Map<String, Object> oneSerDumpedMeta = new HashMap<>(oneDumpedMeta.serialize());
+            Map<String, Object> twoSerDumpedMeta = new HashMap<>(twoDumpedMeta.serialize());
+
+            for (String ignoreKey : Properties.EXCLUDED_ITEM_ATTRIBUTES) {
+                oneSerDumpedMeta.remove(ignoreKey);
+                twoSerDumpedMeta.remove(ignoreKey);
+            }
+
+            if (oneSerDumpedMeta.equals(twoSerDumpedMeta)) {
+                return true;
+            }
         }
 
         // return true if both are null or same, false otherwise

--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.HashMap;
 
 import static com.Acrobot.Breeze.Utils.StringUtil.getMinecraftCharWidth;
 import static com.Acrobot.Breeze.Utils.StringUtil.getMinecraftStringWidth;
@@ -127,8 +128,10 @@ public class MaterialUtil {
         if (oneMeta == twoMeta || oneMeta == null || twoMeta == null) {
             return oneMeta == twoMeta;
         }
-        Map<String, Object> oneSerMeta = oneMeta.serialize();
-        Map<String, Object> twoSerMeta = twoMeta.serialize();
+        Map<String, Object> oneSerMeta = new HashMap<>(oneMeta.serialize());
+        Map<String, Object> twoSerMeta = new HashMap<>(twoMeta.serialize());
+        oneSerMeta.remove("repair-cost");
+        twoSerMeta.remove("repair-cost");
         if (oneSerMeta.equals(twoSerMeta)) {
             return true;
         }

--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -131,8 +131,8 @@ public class MaterialUtil {
 
         Map<String, Object> oneSerMeta = new HashMap<>(oneMeta.serialize());
         Map<String, Object> twoSerMeta = new HashMap<>(twoMeta.serialize());
-        if (!Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY.isEmpty()) {
-            for (String ignoreKey : Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY) {
+        if (!Properties.EXCLUDED_ITEM_ATTRIBUTES.isEmpty()) {
+            for (String ignoreKey : Properties.EXCLUDED_ITEM_ATTRIBUTES) {
                 oneSerMeta.remove(ignoreKey);
                 twoSerMeta.remove(ignoreKey);
             }

--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/MaterialUtil.java
@@ -128,10 +128,18 @@ public class MaterialUtil {
         if (oneMeta == twoMeta || oneMeta == null || twoMeta == null) {
             return oneMeta == twoMeta;
         }
+
         Map<String, Object> oneSerMeta = new HashMap<>(oneMeta.serialize());
         Map<String, Object> twoSerMeta = new HashMap<>(twoMeta.serialize());
-        oneSerMeta.remove("repair-cost");
-        twoSerMeta.remove("repair-cost");
+        System.out.println("IGNORE LIST: ");
+        System.out.println(Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY);
+        if (!Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY.isEmpty()) {
+            for (String ignoreKey : Properties.IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY) {
+                oneSerMeta.remove(ignoreKey);
+                twoSerMeta.remove(ignoreKey);
+            }
+        }
+
         if (oneSerMeta.equals(twoSerMeta)) {
             return true;
         }

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
@@ -18,7 +18,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
-import java.util.Collections;
 
 /**
  * @author Acrobot

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
@@ -342,8 +342,8 @@ public class Properties {
     public static boolean USE_STOCK_COUNTER = false;
 
     @PrecededBySpace
-    @ConfigurationComment("Ignore enchantment attribute for similarity")
+    @ConfigurationComment("Exclude these enchantments from the similarity check when comparing items")
     @Parser("StringSet")
-    public static Set<String> IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY = new LinkedHashSet<>();
+    public static Set<String> EXCLUDED_ITEM_ATTRIBUTES = new LinkedHashSet<>();
 
 }

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
@@ -342,8 +342,7 @@ public class Properties {
     public static boolean USE_STOCK_COUNTER = false;
 
     @PrecededBySpace
-    @ConfigurationComment("Exclude these enchantments from the similarity check when comparing items")
+    @ConfigurationComment("Exclude these item meta attributes from the similarity check when comparing items")
     @Parser("StringSet")
     public static Set<String> EXCLUDED_ITEM_ATTRIBUTES = new LinkedHashSet<>();
-
 }

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Configuration/Properties.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
+import java.util.Collections;
 
 /**
  * @author Acrobot
@@ -340,4 +341,10 @@ public class Properties {
     @PrecededBySpace
     @ConfigurationComment("Add stock counter to quantity line?")
     public static boolean USE_STOCK_COUNTER = false;
+
+    @PrecededBySpace
+    @ConfigurationComment("Ignore enchantment attribute for similarity")
+    @Parser("StringSet")
+    public static Set<String> IGNORE_ENCHANT_ATTRIBUTE_FOR_SIMILARITY = new LinkedHashSet<>();
+
 }


### PR DESCRIPTION
Config to ignore Anvil's repair cost and other attributes for enchanted item