### PR TITLE
[#504] Implement SignName compatability with price restrictions

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Modules/PriceRestrictionModule.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Modules/PriceRestrictionModule.java
@@ -8,6 +8,7 @@ import com.Acrobot.ChestShop.Events.ItemParseEvent;
 import com.Acrobot.ChestShop.Events.PreShopCreationEvent;
 import com.Acrobot.ChestShop.Permission;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
+import com.Acrobot.ChestShop.Utils.ItemUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -42,7 +43,7 @@ public class PriceRestrictionModule implements Listener {
 
         configuration = YamlConfiguration.loadConfiguration(file);
 
-        configuration.options().header("In this file you can configure maximum and minimum prices for items (when creating a shop).");
+        configuration.options().header("In this file you can configure maximum and minimum prices for items (when creating a shop).\nBy default, entries are read as Materials. If you wish to use other items, simply enter the name as written on the /iteminfo command.\nExact matches to the /iteminfo name are prioritised, and materials are a fallback.");
 
         if (!file.exists()) {
             configuration.addDefault("uses_materials", true);
@@ -53,6 +54,11 @@ public class PriceRestrictionModule implements Listener {
 
             configuration.addDefault("min.buy_price.piston_head", 1.03);
             configuration.addDefault("min.sell_price.placed_banner", 0.51);
+
+            // Add example of custom item to the config
+            configuration.addDefault("max.buy_price.Powered Rail#1", 3.51);
+            configuration.addDefault("max.sell_price.Powered Rail#1", 3.52);
+
 
             try {
                 configuration.options().copyDefaults(true);
@@ -101,18 +107,60 @@ public class PriceRestrictionModule implements Listener {
         load();
     }
 
+    /**
+     * Evaluate whether the configPath leads to a item or not
+     * 
+     * @param configPathToItem the config path
+     * @return true if contained in config, false otherwise
+     */
+    private boolean isValid(String configPathToItem) {
+        return configuration.getDouble(configPathToItem, INVALID_PATH) != INVALID_PATH;
+    }
+
+    /**
+     * Get the item reference for an item: First try get path via itemStack's getSignName, if valid
+     * return the getSignName, otherwise return path using itemStack's Material
+     * 
+     * @param maxMinPath The min/max path
+     * @param itemStack The itemstack to get the config path for
+     * @return the getSignName for the itemStack, or the item's material
+     */
+    private String getItemReference(String maxMinPath, ItemStack itemStack) {
+        String signName = ItemUtil.getSignName(itemStack);
+        // If there is a valid path to the itemstack using getSignName, return signName
+        // otherwise return the item material
+        return isValid((maxMinPath + signName)) ? signName
+                : itemStack.getType().toString().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Get the config path for the item 1: First try get path via itemStack's getSignName, if valid
+     * return the getSignName, otherwise return path using itemStack's Material
+     * 
+     * @param maxMinPath The min/max path
+     * @param itemStack The itemstack to get the config path for
+     * @return the config path to the itemstack
+     */
+    private String getConfigPath(String maxMinPath, ItemStack itemStack) {
+        return maxMinPath + getItemReference(maxMinPath, itemStack);
+    }
+
+    private BigDecimal getLimit(String itemConfigPath, int amount) {
+        return BigDecimal.valueOf(configuration.getDouble(itemConfigPath) * amount);
+    }
+
+
     @EventHandler
     public void onPreShopCreation(PreShopCreationEvent event) {
         ItemParseEvent parseEvent = new ItemParseEvent(ChestShopSign.getItem(event.getSignLines()));
         Bukkit.getPluginManager().callEvent(parseEvent);
-        ItemStack material = parseEvent.getItem();
+        ItemStack itemStack = parseEvent.getItem();
         Player player = event.getPlayer();
 
-        if (material == null) {
+        if (itemStack == null) {
             return;
         }
 
-        String itemType = material.getType().toString().toLowerCase(Locale.ROOT);
         int amount;
         try {
             amount = ChestShopSign.getQuantity(event.getSignLines());
@@ -124,41 +172,41 @@ public class PriceRestrictionModule implements Listener {
         if (PriceUtil.hasBuyPrice(priceLine)) {
             BigDecimal buyPrice = PriceUtil.getExactBuyPrice(priceLine);
 
-            BigDecimal minBuyPrice = BigDecimal.valueOf(configuration.getDouble("min.buy_price." + itemType) * amount);
-            if (isValid("min.buy_price." + itemType) && buyPrice.compareTo(minBuyPrice) < 0
-                    && !Permission.has(player, NOLIMIT_MIN_BUY) && !Permission.has(player, NOLIMIT_MIN_BUY_ID + itemType)) {
+            String minBuyItemPath = getConfigPath("min.buy_price.", itemStack);
+            BigDecimal minBuyPrice = getLimit(minBuyItemPath, amount);
+            if (isValid(minBuyItemPath) && buyPrice.compareTo(minBuyPrice) < 0
+                    && !Permission.has(player, NOLIMIT_MIN_BUY) && !Permission.has(player, NOLIMIT_MIN_BUY_ID + getItemReference("min.buy_price.", itemStack))) {
                 event.setOutcome(BUY_PRICE_BELOW_MIN);
                 Messages.BUY_PRICE_BELOW_MIN.sendWithPrefix(player, "price", buyPrice.toPlainString(), "minprice", minBuyPrice.toPlainString());
             }
 
-            BigDecimal maxBuyPrice = BigDecimal.valueOf(configuration.getDouble("max.buy_price." + itemType) * amount);
-            if (isValid("max.buy_price." + itemType) && buyPrice.compareTo(maxBuyPrice) > 0
-                    && !Permission.has(player, NOLIMIT_MAX_BUY) && !Permission.has(player, NOLIMIT_MAX_BUY_ID + itemType)) {
+            String maxBuyItemPath = getConfigPath("max.buy_price.", itemStack);
+            BigDecimal maxBuyPrice = getLimit(maxBuyItemPath, amount);
+            if (isValid(maxBuyItemPath) && buyPrice.compareTo(maxBuyPrice) > 0
+                    && !Permission.has(player, NOLIMIT_MAX_BUY) && !Permission.has(player, NOLIMIT_MAX_BUY_ID + getItemReference("max.buy_price.", itemStack))) {
                 event.setOutcome(BUY_PRICE_ABOVE_MAX);
-                Messages.BUY_PRICE_ABOVE_MAX.sendWithPrefix(player, "price", buyPrice.toPlainString(),  "maxprice", maxBuyPrice.toPlainString());
+                Messages.BUY_PRICE_ABOVE_MAX.sendWithPrefix(player, "price", buyPrice.toPlainString(), "maxprice", maxBuyPrice.toPlainString());
             }
         }
 
         if (PriceUtil.hasSellPrice(priceLine)) {
             BigDecimal sellPrice = PriceUtil.getExactSellPrice(priceLine);
 
-            BigDecimal minSellPrice = BigDecimal.valueOf(configuration.getDouble("min.sell_price." + itemType) * amount);
-            if (isValid("min.sell_price." + itemType) && sellPrice.compareTo(minSellPrice) < 0
-                    && !Permission.has(player, NOLIMIT_MIN_SELL) && !Permission.has(player, NOLIMIT_MIN_SELL_ID + itemType)) {
+            String minSellItemPath = getConfigPath("min.sell_price.", itemStack);
+            BigDecimal minSellPrice = getLimit(minSellItemPath, amount);
+            if (isValid(minSellItemPath) && sellPrice.compareTo(minSellPrice) < 0
+                    && !Permission.has(player, NOLIMIT_MIN_SELL) && !Permission.has(player, NOLIMIT_MIN_SELL_ID + getItemReference("min.sell_price.", itemStack))) {
                 event.setOutcome(SELL_PRICE_BELOW_MIN);
                 Messages.SELL_PRICE_BELOW_MIN.sendWithPrefix(player, "price", sellPrice.toPlainString(),  "minprice", minSellPrice.toPlainString());
             }
 
-            BigDecimal maxSellPrice = BigDecimal.valueOf(configuration.getDouble("max.sell_price." + itemType) * amount);
-            if (isValid("max.sell_price." + itemType) && sellPrice.compareTo(maxSellPrice) > 0
-                    && !Permission.has(player, NOLIMIT_MAX_SELL) && !Permission.has(player, NOLIMIT_MAX_SELL_ID + itemType)) {
+            String maxSellItemPath = getConfigPath("max.sell_price.", itemStack);
+            BigDecimal maxSellPrice = getLimit(maxSellItemPath, amount);
+            if (isValid(maxSellItemPath) && sellPrice.compareTo(maxSellPrice) > 0
+                    && !Permission.has(player, NOLIMIT_MAX_SELL) && !Permission.has(player, NOLIMIT_MAX_SELL_ID + getItemReference("max.sell_price.", itemStack))) {
                 event.setOutcome(SELL_PRICE_ABOVE_MAX);
                 Messages.SELL_PRICE_ABOVE_MAX.sendWithPrefix(player, "price", sellPrice.toPlainString(),  "maxprice", maxSellPrice.toPlainString());
             }
         }
-    }
-
-    private boolean isValid(String path) {
-        return configuration.getDouble(path, INVALID_PATH) != INVALID_PATH;
     }
 }


### PR DESCRIPTION
This is a proposed implementation for #504 Allow price limits for different item IDs.

The solution changes the PriceRestrictionModule to try to find a configured price restriction for the Item's ItemUtil#getSignName result. If none is found, it falls back to the item material as per the original implementation.

I've tested this briefly locally and it seems to work a treat with Slimefun4 items whilst maintaining compatibility with Vanilla items.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#504: Allow price limits for different item ids such as Player Head#1 from Slimefun](https://oss.issuehunt.io/repos/1751509/issues/504)
- [#504: Allow price limits for different item ids such as Player Head#1 from Slimefun](https://oss.issuehunt.io/repos/1751509/issues/504)
---
</details>
<!-- /Issuehunt content-->