### PR TITLE
#487 - Add Plotsquared Flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,24 @@
             <version>2.10-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.intellectualsites.plotsquared</groupId>
+            <artifactId>plotsquared-core</artifactId>
+            <version>7.5.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.intellectualsites.plotsquared</groupId>
+            <artifactId>plotsquared-bukkit</artifactId>
+            <version>7.5.3</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>plotsquared-core</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -54,7 +54,6 @@ public class Dependencies implements Listener {
         switch (dependency) {
             //Protection plugins
             case PlotSquared:
-                System.out.println("1");
                 ChestshopAllowShopFlag.ALLOW_SHOP_FLAG_TRUE.getName(); // force the static code to run
                 break;
             //Terrain protection plugins

--- a/src/main/java/com/Acrobot/ChestShop/Dependencies.java
+++ b/src/main/java/com/Acrobot/ChestShop/Dependencies.java
@@ -52,6 +52,11 @@ public class Dependencies implements Listener {
         }
 
         switch (dependency) {
+            //Protection plugins
+            case PlotSquared:
+                System.out.println("1");
+                ChestshopAllowShopFlag.ALLOW_SHOP_FLAG_TRUE.getName(); // force the static code to run
+                break;
             //Terrain protection plugins
             case WorldGuard:
                 WorldGuardFlags.ENABLE_SHOP.getName();  // force the static code to run
@@ -165,6 +170,9 @@ public class Dependencies implements Listener {
 
                 listener = new ResidenceChestProtection();
                 break;
+            case PlotSquared:
+                listener = new PlotSquared();
+                break;
 
             //Terrain protection plugins
             case WorldGuard:
@@ -244,7 +252,8 @@ public class Dependencies implements Listener {
 
         ItemBridge,
 
-        ShowItem;
+        ShowItem,
+        PlotSquared;
 
         private final String author;
 

--- a/src/main/java/com/Acrobot/ChestShop/Plugins/ChestshopAllowShopFlag.java
+++ b/src/main/java/com/Acrobot/ChestShop/Plugins/ChestshopAllowShopFlag.java
@@ -1,0 +1,40 @@
+package com.Acrobot.ChestShop.Plugins;
+
+import com.Acrobot.ChestShop.ChestShop;
+import com.plotsquared.core.configuration.caption.TranslatableCaption;
+import com.plotsquared.core.plot.flag.types.BooleanFlag;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class ChestshopAllowShopFlag extends BooleanFlag<ChestshopAllowShopFlag> {
+    public static final ChestshopAllowShopFlag ALLOW_SHOP_FLAG_TRUE = new ChestshopAllowShopFlag(true);
+    public static final ChestshopAllowShopFlag ALLOW_SHOP_FLAG_FALSE = new ChestshopAllowShopFlag(false);
+
+    private ChestshopAllowShopFlag(final boolean value) {
+        super(value, TranslatableCaption.of("flags.flag_description_allow_shop"));
+    }
+
+    static {
+        // This is a workaround for the fact that PlotSquared's GlobalFlagContainer is not initialized at the time of plugin load.
+
+        ChestShop.runInAsyncThread(() -> {
+            com.plotsquared.core.plot.flag.GlobalFlagContainer flagContainer = com.plotsquared.core.plot.flag.GlobalFlagContainer.getInstance();
+
+            while (flagContainer == null) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                flagContainer = com.plotsquared.core.plot.flag.GlobalFlagContainer.getInstance();
+                if(flagContainer == null) continue;
+
+                flagContainer.addFlag(ALLOW_SHOP_FLAG_TRUE);
+            }
+        });
+    }
+
+    @Override
+    protected ChestshopAllowShopFlag flagOf(@NonNull final Boolean value) {
+        return value ? ALLOW_SHOP_FLAG_TRUE : ALLOW_SHOP_FLAG_FALSE;
+    }
+}

--- a/src/main/java/com/Acrobot/ChestShop/Plugins/PlotSquared.java
+++ b/src/main/java/com/Acrobot/ChestShop/Plugins/PlotSquared.java
@@ -1,0 +1,30 @@
+package com.Acrobot.ChestShop.Plugins;
+
+import com.Acrobot.ChestShop.Events.Protection.BuildPermissionEvent;
+import com.plotsquared.core.location.Location;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotArea;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlotSquared implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void canBuild(BuildPermissionEvent event) {
+        Block block = event.getSign().getBlock();
+
+        Location location = com.plotsquared.bukkit.util.BukkitUtil.adapt(block.getLocation());
+        Plot plot = location.getPlot();
+
+        if(plot == null) {
+            event.allow(false);
+            return;
+        }
+
+        if(!plot.getFlag(ChestshopAllowShopFlag.class)) {
+            event.allow(false);
+        }
+    }
+}
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '${bukkit.plugin.version}'
 author: Acrobot
 authors: ['https://github.com/ChestShop-authors/ChestShop-3/contributors']
 description: A chest shop for economy plugins.
-softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, BlockLocker, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem, ItemBridge]
+softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, BlockLocker, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem, ItemBridge, PlotSquared]
 api-version: '1.13'
 folia-supported: true
 


### PR DESCRIPTION
Adds PlotSquared flag to ChestShop.

The Async task is neccesary because the GlobalFlagContainer gets constructed later in PlotSquared. We load dependencies in onLoad, but the container isn't available before the onEnable in PlotSquared.

The file is called `ChestshopAllowShopFlag` because the name of the flag is constructed from the name of the class. There's no possibilty to override this.
The name of the flag in game is `chestshop-allow-shop`.

PlotSquared can be compiled from source from https://github.com/IntellectualSites/PlotSquared

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#487: PlotSquared flag](https://oss.issuehunt.io/repos/1751509/issues/487)
---
</details>
<!-- /Issuehunt content-->