### PR TITLE
Adding support for formatted prices

### DIFF
--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/PriceUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/PriceUtil.java
@@ -65,7 +65,7 @@ public class PriceUtil {
     }
 
     /**
-     * Utility method to remove all defined suffix multipliers (as defined in {@link PriceUtil#MULTIPLIERS}
+     * Utility method to remove all defined suffix multipliers (as defined in {@link PriceUtil#MULTIPLIERS})
      * @param part String to modify
      * @return The string with all defined multiplier suffixes removed
      */

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/PreShopCreation/PriceChecker.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/PreShopCreation/PriceChecker.java
@@ -30,14 +30,14 @@ public class PriceChecker implements Listener {
         line = line.replaceAll("(\\.\\d*[1-9])0+", "$1"); //remove trailing zeroes
         line = line.replaceAll("(\\d)\\.0+(\\D|$)", "$1$2"); //remove point and zeroes from strings that only have trailing zeros
 
-        String[] part = line.split(":");
+        String[] parts = line.split(":");
 
-        if (part.length > 1 && (isInvalid(part[0]) ^ isInvalid(part[1]))) {
+        if (parts.length > 1 && (isInvalid(parts[0]) ^ isInvalid(parts[1]))) {
             line = line.replace(':', ' ');
-            part = new String[]{line};
+            parts = new String[]{line};
         }
 
-        if (part[0].split(" ").length > 2) {
+        if (parts[0].split(" ").length > 2) {
             event.setOutcome(INVALID_PRICE);
             return;
         }
@@ -47,11 +47,11 @@ public class PriceChecker implements Listener {
             return;
         }
 
-        if (isPrice(part[0])) {
+        if (isPrice(parts[0])) {
             line = "B " + line;
         }
 
-        if (part.length > 1 && isPrice(part[1])) {
+        if (parts.length > 1 && isPrice(parts[1])) {
             line += " S";
         }
 
@@ -63,6 +63,14 @@ public class PriceChecker implements Listener {
             event.setOutcome(INVALID_PRICE);
             return;
         }
+
+        for (String part : parts) {
+            if (!PriceUtil.hasSingleMultiplier(part)) {
+                event.setOutcome(INVALID_PRICE);
+                return;
+            }
+        }
+
 
         event.setSignLine(PRICE_LINE, line);
 

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Signs/ChestShopSign.java
@@ -41,11 +41,11 @@ public class ChestShopSign {
     public static final Pattern[][] SHOP_SIGN_PATTERN = {
             { Pattern.compile("^[1-9][0-9]{0,5}$"), QuantityUtil.QUANTITY_LINE_WITH_COUNTER_PATTERN },
             {
-                Pattern.compile("(?i)^((\\d*([.e]\\d+)?)|free)$"),
-                Pattern.compile("(?i)^([BS] *((\\d*([.e]\\d+)?)|free))( *: *([BS] *((\\d*([.e]\\d+)?)|free)))?$"),
-                Pattern.compile("(?i)^(((\\d*([.e]\\d+)?)|free) *[BS])( *: *([BS] *((\\d*([.e]\\d+)?)|free)))?$"),
-                Pattern.compile("(?i)^(((\\d*([.e]\\d+)?)|free) *[BS]) *: *(((\\d*([.e]\\d+)?)|free) *[BS])$"),
-                Pattern.compile("(?i)^([BS] *((\\d*([.e]\\d+)?)|free)) *: *(((\\d*([.e]\\d+)?)|free) *[BS])$"),
+                Pattern.compile("(?i)^((\\d*([.e]\\d+)?)([KM])?|free)$"),
+                Pattern.compile("(?i)^([BS] *((\\d*([.e]\\d+)?([KM])?)|free))( *: *([BS] *((\\d*([.e]\\d+)?([KM])?)|free)))?$"),
+                Pattern.compile("(?i)^(((\\d*([.e]\\d+)?([KM] )?)|free) *[BS])( *: *([BS] *((\\d*([.e]\\d+)?([KM])?)|free)))?$"),
+                Pattern.compile("(?i)^(((\\d*([.e]\\d+)?([KM] )?)|free) *[BS]) *: *(((\\d*([.e]\\d+)?([KM] )?)|free) *[BS])$"),
+                Pattern.compile("(?i)^([BS] *((\\d*([.e]\\d+)?([KM])?)|free)) *: *(((\\d*([.e]\\d+)?([KM] ?)|free) *[BS])$"),
             },
             { Pattern.compile("^[\\p{L}\\d_? #:\\-]+$") }
     };

--- a/plugin/src/test/java/com/Acrobot/ChestShop/Tests/PriceCheckerTest.java
+++ b/plugin/src/test/java/com/Acrobot/ChestShop/Tests/PriceCheckerTest.java
@@ -146,7 +146,7 @@ public class PriceCheckerTest {
         onPreShopCreation(event);
         assertTrue(event.isCancelled());
 
-        event = new PreShopCreationEvent(null, null, getPriceString("S -100"));
+        event = new PreShopCreationEvent(null, null, getPriceString("B -100"));
         onPreShopCreation(event);
         assertTrue(event.isCancelled());
 


### PR DESCRIPTION
Per #624, I have made some changes to support some formatted prices.

- The `K` suffix can be used to denote thousands (10K for 10,000)
- The `M` suffix can be used to denote millions (1M for 1,000,000)

Though I did not add a suffix for billions, as the clear choice of `B` would of course conflict with the default "buy" character. Even so, there is some potential for confusion if a user thinks the "B" suffix stands for billions and accidentally sets their valuable item price to "1B"! :laughing: 

Regardless, support for billions and beyond can be added in the future, just require an update to patterns in the ChestSignShop class and adding a mapping in PriceUtil

Also I have included some test cases to ensure prices work as expected.

Formatting rules for new currency:

- If the buy/sell indicator is put after the price, then there must be a space between it and the multiplier
    - "10KB" won't work, it must be "10K B"
- A buy/sell price cannot have multiple suffixes ("10KM" won't work)