### PR TITLE
Bug fix for hasSingleMultiplier method

### DIFF
--- a/plugin/src/main/java/com/Acrobot/Breeze/Utils/PriceUtil.java
+++ b/plugin/src/main/java/com/Acrobot/Breeze/Utils/PriceUtil.java
@@ -87,14 +87,12 @@ public class PriceUtil {
      * @return true if the given string has 0 or 1 multiplier characters
      */
     public static boolean hasSingleMultiplier(String part) {
-        boolean foundMultiplier = false;
+        int count = 0;
 
         for (Character c : MULTIPLIERS.keySet()) {
-            if (foundMultiplier) {
-                return false;
-            }
+            if (part.toLowerCase(Locale.ROOT).contains(c.toString())) count++;
 
-            foundMultiplier = part.contains(c.toString());
+            if (count > 1) return false;
         }
 
         return true;


### PR DESCRIPTION
Relating to #638, the newly introduced `hasSingleMultiplier` method has a couple bugs:
- No case-insensitive  matching, so "10KM" will return true when it should return false
- Fixing the case-insensitive matching, the method will always return false if the string has even a single multiplier

This PR is just a small update to fix this behaviour