### PR TITLE
Include AuthMe as a softdepend

### DIFF
--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '${bukkit.plugin.version}'
 author: Acrobot
 authors: ['https://github.com/ChestShop-authors/ChestShop-3/contributors']
 description: A chest shop for economy plugins.
-softdepend: [Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, BlockLocker, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem, ItemBridge]
+softdepend: [AuthMe, Vault, Reserve, LWC, Lockette, LockettePro, Deadbolt, BlockLocker, OddItem, WorldGuard, GriefPrevention, RedProtect, Heroes, SimpleChestLock, Residence, ShowItem, ItemBridge]
 api-version: '1.13'
 folia-supported: true
 


### PR DESCRIPTION
Closes #546.

ChestShop doesn't specify AuthMe as a softdepend in plugin.yml, which causes the plugin load order cannot be determined and leads to a `NoClassDefFoundError`.