### PR TITLE
Add StockUpdateEvent

### DIFF
--- a/plugin/src/main/java/com/Acrobot/ChestShop/Events/StockUpdateEvent.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Events/StockUpdateEvent.java
@@ -1,0 +1,51 @@
+package com.Acrobot.ChestShop.Events;
+
+import org.bukkit.block.Sign;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a state after a shop's stock changes
+ *
+ * @author bjorn-out
+ */
+public class StockUpdateEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final int stock;
+    private final Sign sign;
+
+    public StockUpdateEvent(int stock, Sign sign) {
+        this.stock = stock;
+        this.sign = sign;
+    }
+
+    /**
+     * @return Stock available (number of items)
+     */
+    public int getStock() {
+        return stock;
+    }
+
+    /**
+     * @return Shop's sign
+     */
+    public Sign getSign() {
+        return sign;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public static boolean hasHandlers() {
+        return handlers.getRegisteredListeners().length > 0;
+    }
+
+    @Override
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemMoveListener.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemMoveListener.java
@@ -1,9 +1,14 @@
 package com.Acrobot.ChestShop.Listeners.Item;
 
+import com.Acrobot.ChestShop.ChestShop;
 import com.Acrobot.ChestShop.Configuration.Properties;
-import com.Acrobot.ChestShop.Listeners.Modules.StockCounterModule;
+import com.Acrobot.ChestShop.Events.StockUpdateEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
+import com.Acrobot.ChestShop.Utils.uBlock;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -11,6 +16,7 @@ import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.InventoryHolder;
 
 import static com.Acrobot.Breeze.Utils.ImplementationAdapter.getHolder;
+import static com.Acrobot.ChestShop.Listeners.Modules.StockCounterModule.fireStockUpdateEvents;
 
 /**
  * @author Acrobot
@@ -28,8 +34,12 @@ public class ItemMoveListener implements Listener {
                 return;
             }
         }
-        if (Properties.USE_STOCK_COUNTER && ChestShopSign.isShopBlock(destinationHolder)) {
-            StockCounterModule.updateCounterOnItemMoveEvent(event.getItem(), destinationHolder);
+
+        if (StockUpdateEvent.hasHandlers() && ChestShopSign.isShopBlock(destinationHolder)) {
+            Block shopBlock = ChestShopSign.getShopBlock(destinationHolder);
+
+            Bukkit.getScheduler().runTask(ChestShop.getPlugin(), () ->
+                    fireStockUpdateEvents(event.getDestination()));
         }
     }
 

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemMoveListener.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/Item/ItemMoveListener.java
@@ -4,11 +4,8 @@ import com.Acrobot.ChestShop.ChestShop;
 import com.Acrobot.ChestShop.Configuration.Properties;
 import com.Acrobot.ChestShop.Events.StockUpdateEvent;
 import com.Acrobot.ChestShop.Signs.ChestShopSign;
-import com.Acrobot.ChestShop.Utils.uBlock;
 import org.bukkit.Bukkit;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.Sign;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -36,8 +33,6 @@ public class ItemMoveListener implements Listener {
         }
 
         if (StockUpdateEvent.hasHandlers() && ChestShopSign.isShopBlock(destinationHolder)) {
-            Block shopBlock = ChestShopSign.getShopBlock(destinationHolder);
-
             Bukkit.getScheduler().runTask(ChestShop.getPlugin(), () ->
                     fireStockUpdateEvents(event.getDestination()));
         }

--- a/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/StockUpdateListener.java
+++ b/plugin/src/main/java/com/Acrobot/ChestShop/Listeners/StockUpdateListener.java
@@ -1,0 +1,55 @@
+package com.Acrobot.ChestShop.Listeners;
+
+import com.Acrobot.Breeze.Utils.QuantityUtil;
+import com.Acrobot.ChestShop.ChestShop;
+import com.Acrobot.ChestShop.Configuration.Properties;
+import com.Acrobot.ChestShop.Events.StockUpdateEvent;
+import com.Acrobot.ChestShop.Signs.ChestShopSign;
+import org.bukkit.block.Sign;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import java.util.IllegalFormatException;
+
+import static com.Acrobot.ChestShop.Signs.ChestShopSign.QUANTITY_LINE;
+
+/**
+ * @author bjorn-out
+ */
+public class StockUpdateListener implements Listener {
+    private static final String PRICE_LINE_WITH_COUNT = "Q %d : C %d";
+
+    @EventHandler(priority = EventPriority.LOW)
+    public static void onStockUpdate(StockUpdateEvent event) {
+        int quantity;
+        try {
+            quantity = ChestShopSign.getQuantity(event.getSign());
+        } catch (IllegalFormatException invalidQuantity) {
+            return;
+        }
+
+        if (Properties.FORCE_UNLIMITED_ADMIN_SHOP && ChestShopSign.isAdminShop(event.getSign().getLines())) {
+            removeCounter(event.getSign(), quantity);
+            return;
+        }
+
+        if (Properties.MAX_SHOP_AMOUNT > 99999) {
+            ChestShop.getBukkitLogger().warning("Stock counter cannot be used if MAX_SHOP_AMOUNT is over 5 digits");
+            removeCounter(event.getSign(), quantity);
+            return;
+        }
+
+        event.getSign().setLine(QUANTITY_LINE, String.format(PRICE_LINE_WITH_COUNT, quantity, event.getStock()));
+        event.getSign().update(true);
+    }
+
+    private static void removeCounter(Sign sign, int quantity) {
+        if (!QuantityUtil.quantityLineContainsCounter(ChestShopSign.getQuantityLine(sign.getLines()))) {
+            return;
+        }
+
+        sign.setLine(QUANTITY_LINE, Integer.toString(quantity));
+        sign.update(true);
+    }
+}


### PR DESCRIPTION
This change adds an event `StockUpdateEvent`, which fires when the stock inside of a shop changes.

ChestShop listens to this event if the `USE_STOCK_COUNTER` property is set to `true` in order to update the stock counter on the shop sign. If this property is set to `false` and no other plugins are listening for the event, all logic for this event is disabled and the event is not fired, prioritising performance.